### PR TITLE
Find command: convert to streams

### DIFF
--- a/src/main/java/brobot/BroBot.java
+++ b/src/main/java/brobot/BroBot.java
@@ -2,6 +2,7 @@
 package brobot;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import brobot.brobotexceptions.BrobotCommandFormatException;
@@ -26,7 +27,7 @@ public final class BroBot {
     }
 
     public List<FileIOStatus> getLoadMessages() {
-        return List.copyOf(loadMessages);
+        return Collections.unmodifiableList(loadMessages);
     }
 
     public static BroBot getSingleton() {

--- a/src/main/java/brobot/Storage.java
+++ b/src/main/java/brobot/Storage.java
@@ -61,7 +61,7 @@ public final class Storage {
                         taskStringBuilder.deleteCharAt(taskStringBuilder.length() - 1);
                     }
                 } else {
-                    taskStringBuilder.append(taskLine + "\n");
+                    taskStringBuilder.append(taskLine + System.lineSeparator());
                 }
             }
 
@@ -69,7 +69,7 @@ public final class Storage {
                             FileIOStatus.makeSuccessStatus("You do not have any tasks saved from previous sessions."), () -> {
                         final String line1 = "Here are the tasks saved from previous sessions.";
                         final String line2 = TaskList.getSingleton().toString();
-                        return FileIOStatus.makeSuccessStatus(String.join("\n", line1, line2));
+                        return FileIOStatus.makeSuccessStatus(String.join(System.lineSeparator(), line1, line2));
                 }));
 
         } catch (final IOException ioException) {
@@ -77,11 +77,11 @@ public final class Storage {
                 final String line1 = "Oh no, the system had a problem reading the file where your tasks were saved.";
                 final String line2 = "Trying again. Hang in there.";
 
-                return FileIOStatus.makeFailureStatus(String.join("\n", line1, line2));
+                return FileIOStatus.makeFailureStatus(String.join(System.lineSeparator(), line1, line2));
             }, () -> {
                 final String line1 = "Oh no, the system had a problem reading the file where your tasks were saved.";
                 final String line2 = "Trying again. Hang in there.";
-                return FileIOStatus.makeFailureStatus(String.join("\n", line1, line2));
+                return FileIOStatus.makeFailureStatus(String.join(System.lineSeparator(), line1, line2));
             }));
         } finally {
             if (fileReader != null) {
@@ -118,7 +118,9 @@ public final class Storage {
             return FileIOStatus.makeSuccessStatus("Your tasks have successfully been saved to the hard drive.");
         } catch (IOException e) {
             return FileIOStatus.makeFailureStatus(
-                    "Oh no, the system has a problem writing the tasks to the hard disk.\nTrying again. Hang in there."
+                    String.join("Oh no, the system has a problem writing the tasks to the hard disk.",
+                            "Trying again. Hang in there.",
+                                 System.lineSeparator())
             );
         }
     }

--- a/src/main/java/brobot/TaskList.java
+++ b/src/main/java/brobot/TaskList.java
@@ -138,7 +138,7 @@ public final class TaskList {
         } else {
             final StringBuilder ans = new StringBuilder();
             for (int i = 1; i <= getSize(); i++) {
-                ans.append(formatTask(i)).append("\n");
+                ans.append(formatTask(i)).append(System.lineSeparator());
             }
 
             return ans.substring(0, ans.length() - 1);

--- a/src/main/java/brobot/brobotexceptions/BrobotCommandFormatException.java
+++ b/src/main/java/brobot/brobotexceptions/BrobotCommandFormatException.java
@@ -13,7 +13,9 @@ import brobot.FileIOStatus;
  */
 public abstract class BrobotCommandFormatException extends BrobotCheckedException implements BrobotMessenger {
     private static final String INVALID_INPUT_WARNING = "Sorry, this input is invalid!";
-    private static final String ANOTHER_CHANCE_OFFERING = "Please enter a different input.\nProgram resumed.";
+    private static final String ANOTHER_CHANCE_OFFERING = String.join(System.lineSeparator(),
+                                                            "Please enter a different input.",
+                                                                      "Program resumed.");
 
 
     /**
@@ -33,7 +35,7 @@ public abstract class BrobotCommandFormatException extends BrobotCheckedExceptio
     }
 
     private static final String getFullMessage(final String mainMessage) {
-        return String.join("\n",
+        return String.join(System.lineSeparator(),
                 BrobotCommandFormatException.INVALID_INPUT_WARNING,
                 mainMessage,
                 BrobotCommandFormatException.ANOTHER_CHANCE_OFFERING);

--- a/src/main/java/brobot/brobotexceptions/BrobotDateFormatException.java
+++ b/src/main/java/brobot/brobotexceptions/BrobotDateFormatException.java
@@ -31,6 +31,6 @@ public final class BrobotDateFormatException extends BrobotCommandFormatExceptio
 
         final String line5 = "yyyy: Year must have exactly 4 digits.";
 
-        return new BrobotDateFormatException(String.join("\n", "", line1, line2, line3, line4, line5, ""));
+        return new BrobotDateFormatException(String.join(System.lineSeparator(), "", line1, line2, line3, line4, line5, ""));
     }
 }

--- a/src/main/java/brobot/commands/AddTaskCommand.java
+++ b/src/main/java/brobot/commands/AddTaskCommand.java
@@ -55,11 +55,12 @@ public final class AddTaskCommand extends FileIOCommand {
                     + TaskList.getSingleton().formatTask(TaskList.getSingleton().getSize());
 
 
-            final String line3 = String.format("Now you have %d tasks in the list.\n", TaskList.getSingleton().getSize());
+            final String line3 = String.format("Now you have %d tasks in the list.", TaskList.getSingleton().getSize())
+                                    + System.lineSeparator();
 
             final String line4 = "Your tasks have successfully been saved to the hard drive.";
 
-            return FileIOStatus.makeSuccessStatus(String.join("\n", line1, line2, line3, line4));
+            return FileIOStatus.makeSuccessStatus(String.join(System.lineSeparator(), line1, line2, line3, line4));
         } catch (final BrobotCommandFormatException badTaskCommand) {
             return badTaskCommand.sendBrobotMessage();
         }

--- a/src/main/java/brobot/commands/DeleteCommand.java
+++ b/src/main/java/brobot/commands/DeleteCommand.java
@@ -41,10 +41,11 @@ public final class DeleteCommand extends FileIOCommand {
                     + TaskList.getSingleton().formatTask(deleteIndex);
 
             TaskList.getSingleton().removeFromTaskList(deleteIndex);
-            final String line3 = String.format("Now you have %d tasks in the list.\n", TaskList.getSingleton().getSize());
+            final String line3 = String.format("Now you have %d tasks in the list.", TaskList.getSingleton().getSize())
+                                        + System.lineSeparator();
             final String line4 = "Your tasks have successfully been saved to the hard drive.";
 
-            return FileIOStatus.makeSuccessStatus(String.join("\n", line1, line2, line3, line4));
+            return FileIOStatus.makeSuccessStatus(String.join(System.lineSeparator(), line1, line2, line3, line4));
         };
 
         return FileIOStatus.makeSuccessStatus(TaskList.getSingleton().noTaskCheerOrElse(orElse));

--- a/src/main/java/brobot/commands/FindCommand.java
+++ b/src/main/java/brobot/commands/FindCommand.java
@@ -1,8 +1,10 @@
 package brobot.commands;
 
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import brobot.FileIOStatus;
 import brobot.TaskList;
-import brobot.tasks.Task;
 
 /**
  * This command is used to find tasks by keyword (literal String)
@@ -24,14 +26,13 @@ public final class FindCommand extends Command {
 
     @Override
     public FileIOStatus sendBrobotMessage() {
-        final StringBuilder ans = new StringBuilder();
-        for (int i = 1; i <= TaskList.getSingleton().getSize(); i++) {
-            final Task currTask = TaskList.getSingleton().getTask(i);
-            if (currTask.findKeywordInTaskDescription(keyword)) {
-                ans.append(TaskList.formatTask(i, currTask)).append("\n");
-            }
-        }
-
-        return FileIOStatus.makeSuccessStatus(ans.toString());
+        return FileIOStatus.makeSuccessStatus(
+                IntStream.rangeClosed(1, TaskList.getSingleton().getSize())
+                         .filter((final int i) -> TaskList.getSingleton()
+                                                          .getTask(i)
+                                                          .findKeywordInTaskDescription(keyword))
+                         .<String>mapToObj((final int i) -> TaskList.formatTask(i, TaskList.getSingleton().getTask(i)))
+                         .collect(Collectors.joining(System.lineSeparator()))
+        );
     }
 }

--- a/src/main/java/brobot/commands/MarkCommand.java
+++ b/src/main/java/brobot/commands/MarkCommand.java
@@ -32,7 +32,7 @@ public final class MarkCommand extends FileIOCommand {
                     + TaskList.getSingleton().formatTask(markIndex);
 
             final String line3 = "Your tasks have successfully been saved to the hard drive.";
-            return FileIOStatus.makeSuccessStatus(String.join("\n", line1, line2, line3));
+            return FileIOStatus.makeSuccessStatus(String.join(System.lineSeparator(), line1, line2, line3));
         }));
     }
 }

--- a/src/main/java/brobot/commands/UnmarkCommand.java
+++ b/src/main/java/brobot/commands/UnmarkCommand.java
@@ -40,7 +40,7 @@ public final class UnmarkCommand extends FileIOCommand {
 
             final String line3 = "Your tasks have successfully been saved to the hard drive.";
 
-            return FileIOStatus.makeSuccessStatus(String.join("\n", line1, line2, line3));
+            return FileIOStatus.makeSuccessStatus(String.join(System.lineSeparator(), line1, line2, line3));
         }));
     }
 }

--- a/src/main/java/brobot/tasks/DeadlineTask.java
+++ b/src/main/java/brobot/tasks/DeadlineTask.java
@@ -68,8 +68,10 @@ final class DeadlineTask extends Task {
      */
     @Override
     public String toFileReport() {
-        return String.format("%s\n%s\n\n",
-                super.toFileReport().substring(0, super.toFileReport().length() - 2),
-                deadline);
+        return String.join(System.lineSeparator(),
+                            super.toFileReport().substring(0, super.toFileReport().length() - 2),
+                            deadline.toString(),
+                            "",
+                            "");
     }
 }

--- a/src/main/java/brobot/tasks/EventTask.java
+++ b/src/main/java/brobot/tasks/EventTask.java
@@ -71,9 +71,11 @@ final class EventTask extends Task {
      */
     @Override
     public String toFileReport() {
-        return String.format("%s\n%s\n%s\n\n",
-                super.toFileReport().substring(0, super.toFileReport().length() - 2),
-                startDate,
-                endDate);
+        return String.join(System.lineSeparator(),
+                           super.toFileReport().substring(0, super.toFileReport().length() - 2),
+                           startDate.toString(),
+                           endDate.toString(),
+                           "",
+                           "");
     }
 }

--- a/src/main/java/brobot/tasks/Task.java
+++ b/src/main/java/brobot/tasks/Task.java
@@ -118,11 +118,12 @@ public abstract class Task implements BrobotFileIoSerializable {
      *     A serialized version of the task for file IO (according to BroBot domain rules).
      */
     public String toFileReport() {
-        return String.format("%s\n%s\n%s\n\n",
-                commandName,
-                isDone,
-                baseObjective);
-
+        return String.join(System.lineSeparator(),
+                           commandName,
+                            isDone + "",
+                            baseObjective,
+                           "",
+                           "");
     }
 
     /**
@@ -133,7 +134,7 @@ public abstract class Task implements BrobotFileIoSerializable {
      *     A Task instance deserialized from the file report by this factory constructor.
      */
     public static final Task fromFileReport(final String fileReport) {
-        final String[] fileReportLines = fileReport.split("\n");
+        final String[] fileReportLines = fileReport.split(System.lineSeparator());
 
         try {
             switch (fileReportLines.length) {

--- a/src/test/java/brobot/tasks/TaskListTest.java
+++ b/src/test/java/brobot/tasks/TaskListTest.java
@@ -46,7 +46,7 @@ public final class TaskListTest implements StatefulTester {
         try {
             TaskList.getSingleton().addToTaskList(Task.createTask("todo", "addToTaskList task"));
 
-            final String expectedToString = "1. [T][ ] addToTaskList task\n";
+            final String expectedToString = "1. [T][ ] addToTaskList task" + System.lineSeparator();
             assertEquals(expectedToString, TaskList.getSingleton().toString());
         } catch (final BrobotCommandFormatException brobotCommandFormatException) {
             assert false;
@@ -64,7 +64,7 @@ public final class TaskListTest implements StatefulTester {
 
             TaskList.getSingleton().removeFromTaskList(2);
 
-            final String expectedToString = "1. [T][ ] task 0\n";
+            final String expectedToString = "1. [T][ ] task 0" + System.lineSeparator();
             assertEquals(expectedToString, TaskList.getSingleton().toString());
         } catch (final BrobotCommandFormatException brobotCommandFormatException) {
             assert false;


### PR DESCRIPTION
Find command used a simple for loop. This is not very declarative and idiomatic.

Thus, a stream pipeline was adopted so that the find command becomes declarative.